### PR TITLE
Omits keys from relationship query on objects

### DIFF
--- a/data/model/Relationship.php
+++ b/data/model/Relationship.php
@@ -211,10 +211,11 @@ class Relationship extends \lithium\core\Object {
 			if (!isset($object->{$from})) {
 				return null;
 			}
+
 			$conditions[$to] = $object->{$from};
 
 			if (is_object($conditions[$to]) && $conditions[$to] instanceof Countable) {
-				$conditions[$to] = iterator_to_array($conditions[$to]);
+				$conditions[$to] = iterator_to_array($conditions[$to], false);
 			}
 		}
 		$fields = $this->fields();


### PR DESCRIPTION
> I'm raising this PR internally just so I can review it myself before I embarrass myself raising it against the real deal

When upgrading Mongo from 2.2 to 2.6, some Relationship queries stopped working.

Here is the difference between a broken query and a working one:

Broken:

```
Array (
    [_id] => Array (
        [$in] => Array (
            [5322458d67d621411d8b456b] => MongoId Object (
                [$id] => 5322458d67d621411d8b456b
            )
        )
    )
)
```

Working:

```
Array (
    [_id] => Array (
        [$in] => Array (
            [0] => MongoId Object (
                [$id] => 5322458d67d621411d8b456b
            )
        )
    )
)
```

This is fine with Mongo 2.2.x, as we saw earlier in my notes, but in 2.6.x, it is rejected with the message:

```
Can't canonicalize query: BadValue needs an array ns:mydev-dev.users

query:{ : { _id: { : { 5322458d67d621411d8b456b: ObjectId('5322458d67d621411d8b456b') } } }, : [] }
```
